### PR TITLE
docs: add v2 route deep link example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,48 @@ OrganicMapsApi.showPointsOnMap(this, "Capitals of the World", points)
 
 If Organic Maps is not installed, the library shows a download dialog instead of crashing.
 
+## Build a multi-stop route with a deep link
+
+The library wraps the point-selection API. Route planning links can be opened
+directly with an `Intent`:
+
+**Java**
+
+```java
+void openDeliveryRoute()
+{
+  final Uri uri = Uri.parse(
+      "om://v2/dir"
+          + "?origin=52.5200,13.4050"
+          + "&origin_name=Warehouse%20Berlin"
+          + "&destination=52.5163,13.3777"
+          + "&destination_name=Customer"
+          + "&waypoints=52.5304,13.3850|52.5450,13.3920"
+          + "&waypoint_names=Pickup%201|Pickup%202"
+          + "&mode=drive");
+  startActivity(new Intent(Intent.ACTION_VIEW, uri));
+}
+```
+
+**Kotlin**
+
+```kotlin
+val uri = Uri.parse(
+    "om://v2/dir"
+        + "?origin=52.5200,13.4050"
+        + "&origin_name=Warehouse%20Berlin"
+        + "&destination=52.5163,13.3777"
+        + "&destination_name=Customer"
+        + "&waypoints=52.5304,13.3850|52.5450,13.3920"
+        + "&waypoint_names=Pickup%201|Pickup%202"
+        + "&mode=drive")
+startActivity(Intent(Intent.ACTION_VIEW, uri))
+```
+
+Use `om://v2/nav` with an omitted `origin` to start navigation from the user's
+current position when the route is ready. If `origin` is an explicit coordinate,
+Organic Maps previews the route instead of starting navigation automatically.
+
 ## Round-trip: let the user pick a point
 
 Register an `ActivityResultLauncher` and launch a `MapRequest` (or `CrosshairRequest`) with pick-point mode enabled.


### PR DESCRIPTION
Adds a README example for opening Organic Maps v2 route deep links directly from Android.

This replaces the closed #16 branch with a narrow README-only diff on top of the current `master` after #15 was merged.

The example uses `/v2/dir` for explicit-origin route preview and documents that `/v2/nav` auto-starts only when `origin` is omitted, matching organicmaps/organicmaps#12678.
